### PR TITLE
Fixing Properties for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,14 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
+    ECHO Appearently the Agent has an older version of npm, thus causing the install script to stop after preinstall
+    ECHO Installing npm-windows-upgrade
+    npm install --global --production npm-windows-upgrade
+    ECHO Installing npm
+    npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.4.1
+  displayName: 'Install npm 6.4.1'
+
+- script: |
     npm config set msvs_version 2015
     npm install
   displayName: 'npm install'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,24 +9,24 @@ pool:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '8.x'
+    versionSpec: '8.12.0'
   displayName: 'Install Node.js'
 
 - script: |
-    ECHO Appearently the Agent has an older version of npm, thus causing the install script to stop after preinstall
+    ECHO Lets make npm static as well
     ECHO Installing npm-windows-upgrade
-    npm install --global --production npm-windows-upgrade
+    CALL "npm install --global --production npm-windows-upgrade"
     ECHO Installing npm
-    npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.4.1
+    CALL "npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.4.1"
   displayName: 'Install npm 6.4.1'
 
 - script: |
-    npm config set msvs_version 2015
-    npm install
+    CALL "npm config set msvs_version 2015"
+    CALL "npm install"
   displayName: 'npm install'
 
 - script: |
-    npm test
+    CALL "npm test"
   displayName: 'npm test'
 
 - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,18 +15,18 @@ steps:
 - script: |
     ECHO Lets make npm static as well
     ECHO Installing npm-windows-upgrade
-    CALL "npm install --global --production npm-windows-upgrade"
+    CALL npm install --global --production npm-windows-upgrade
     ECHO Installing npm
-    CALL "npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.4.1"
+    CALL npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.4.1
   displayName: 'Install npm 6.4.1'
 
 - script: |
-    CALL "npm config set msvs_version 2015"
-    CALL "npm install"
+    CALL npm config set msvs_version 2015
+    CALL npm install
   displayName: 'npm install'
 
 - script: |
-    CALL "npm test"
+    CALL npm test
   displayName: 'npm test'
 
 - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,12 @@ steps:
 - script: |
     npm config set msvs_version 2015
     npm install
+  displayName: 'npm install'
+
+- script: |
     npm test
-  displayName: 'npm install && npm test'
+  displayName: 'npm test'
+
 - task: PublishTestResults@2
   inputs:
     testRunner: JUnit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,10 +12,10 @@ steps:
     versionSpec: '8.12.0'
   displayName: 'Install Node.js'
 
-## THE AGENT HAS ADMIN BUT THE COMMENTED SCIPT SAYS IT DOESN'T. WHY MS WHY?
-
+# The script below is taken from
+# https://github.com/atom/atom/blob/9c58988d9be5deec12069ec88a5f4ecd5ddfd4e3/script/vsts/platforms/windows.yml
+#
 #- script: |
-#    ECHO Lets make npm static as well
 #    ECHO Installing npm-windows-upgrade
 #    CALL npm install --global --production npm-windows-upgrade
 #    ECHO Installing npm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,13 +12,15 @@ steps:
     versionSpec: '8.12.0'
   displayName: 'Install Node.js'
 
-- script: |
-    ECHO Lets make npm static as well
-    ECHO Installing npm-windows-upgrade
-    CALL npm install --global --production npm-windows-upgrade
-    ECHO Installing npm
-    CALL npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.4.1
-  displayName: 'Install npm 6.4.1'
+## THE AGENT HAS ADMIN BUT THE COMMENTED SCIPT SAYS IT DOESN'T. WHY MS WHY?
+
+#- script: |
+#    ECHO Lets make npm static as well
+#    ECHO Installing npm-windows-upgrade
+#    CALL npm install --global --production npm-windows-upgrade
+#    ECHO Installing npm
+#    CALL npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.4.1
+#  displayName: 'Install npm 6.4.1'
 
 - script: |
     CALL npm config set msvs_version 2015

--- a/install.js
+++ b/install.js
@@ -390,12 +390,14 @@ if (os.platform() !== "win32") {
         });
     } else {
         console.log("Install Mode");
+        var re1a1 = fs.readdirSync(__dirname);
+        console.log(re1a1.join("\n");
         run("node-gyp rebuild", 0).then(() => {
             console.log("Copy lib files to Release folder");
             var files = libFiles.slice(0); // clone array
             copyFiles(files, function() {
                 console.log("Done copying files.");
-                process.exit(0);
+                process.exit(1);
             });
         });
     }

--- a/install.js
+++ b/install.js
@@ -392,6 +392,7 @@ if (os.platform() !== "win32") {
         console.log("Install Mode");
         var re1a1 = fs.readdirSync(__dirname);
         console.log(re1a1.join("\n");
+        process.exit(1);
         run("node-gyp rebuild", 0).then(() => {
             console.log("Copy lib files to Release folder");
             var files = libFiles.slice(0); // clone array

--- a/install.js
+++ b/install.js
@@ -390,15 +390,12 @@ if (os.platform() !== "win32") {
         });
     } else {
         console.log("Install Mode");
-        var re1a1 = fs.readdirSync(__dirname);
-        console.log(re1a1.join("\n");
-        process.exit(1);
         run("node-gyp rebuild", 0).then(() => {
             console.log("Copy lib files to Release folder");
             var files = libFiles.slice(0); // clone array
             copyFiles(files, function() {
                 console.log("Done copying files.");
-                process.exit(1);
+                process.exit(0);
             });
         });
     }

--- a/tests.js
+++ b/tests.js
@@ -49,10 +49,10 @@ if (os.platform() !== "win32") {
 } else {
     console.log("Checking if build is successful...");
     console.log("Checking for `build/Release/sodium.node`...");
-    if (exists("./build/Release/sodium.node")) {
+    if (exists("build\\Release\\sodium.node")) {
         console.log("`build/Release/sodium.node` is found, checking if mocha is available...");
 
-        if (exists("./node_modules/.bin/mocha.cmd")) {
+        if (exists("\\node_modules\\.bin\\mocha.cmd")) {
             console.log("mocha is available. Test is starting...");
             run("set NODE_ENV=test&&\"node_modules\\.bin\\mocha.cmd\" --reporter mocha-junit-reporter")
                 .then(() => process.exit(0))

--- a/tests.js
+++ b/tests.js
@@ -32,9 +32,11 @@ function exists(path) {
         fs.accessSync(path, fs.F_OK);
         return true;
     } catch (e) {
-        fs.readdirSync(__dirname).forEach(file => {
-            console.log(file);
-        });
+// Only for debug purposes
+//
+//        fs.readdirSync(__dirname).forEach(file => {
+//            console.log(file);
+//        });
         return false;
     }
 }
@@ -55,7 +57,7 @@ if (os.platform() !== "win32") {
     if (exists("build\\Release\\sodium.node")) {
         console.log("`build/Release/sodium.node` is found, checking if mocha is available...");
 
-        if (exists("\\node_modules\\.bin\\mocha.cmd")) {
+        if (exists("node_modules\\.bin\\mocha.cmd")) {
             console.log("mocha is available. Test is starting...");
             run("set NODE_ENV=test&&\"node_modules\\.bin\\mocha.cmd\" --reporter mocha-junit-reporter")
                 .then(() => process.exit(0))

--- a/tests.js
+++ b/tests.js
@@ -32,6 +32,9 @@ function exists(path) {
         fs.accessSync(path, fs.F_OK);
         return true;
     } catch (e) {
+        fs.readdirSync(__dirname).forEach(file => {
+            console.log(file);
+        });
         return false;
     }
 }


### PR DESCRIPTION
Appearently Azure Pipelines was skipping our commands due to their execution nature.

* Each `script` block is written to a `.cmd` (Batch) file.
* The file is executed with `cmd`'s `CALL` command.

If any of the commands are executed with another Batch file (Ex: The command `npm` is actually `npm.cmd`); When the "executed" Batch file exits, the main Batch file that contains all the other code also exits. Hence why there were no logs of the commands the Agent executed after `Node.js Install`.

The easiest solution is to append the command `CALL` on each `npm` command.

To find out why the logs were empty, I have created the branch `azure-pipelines-tests` and done experiments on it. After the discovery, I have fixed the `azure-pipelines.yml` file and created this PR.